### PR TITLE
Update GNOME runtime to version 47

### DIFF
--- a/fr.romainvigier.MetadataCleaner.yaml
+++ b/fr.romainvigier.MetadataCleaner.yaml
@@ -1,6 +1,6 @@
 app-id: fr.romainvigier.MetadataCleaner
 runtime: org.gnome.Platform
-runtime-version: '46'
+runtime-version: '47'
 sdk: org.gnome.Sdk
 command: metadata-cleaner
 
@@ -8,7 +8,7 @@ add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
     add-ld-path: .
-    version: '23.08'
+    version: '24.08'
 
 finish-args:
   - --socket=wayland


### PR DESCRIPTION
GNOME runtime version 46 will reach EOL on 2025-03-15.

Source: https://release.gnome.org/calendar/